### PR TITLE
Change script to extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <a href='https://ko-fi.com/O4O5GU04F' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://storage.ko-fi.com/cdn/kofi2.png?v=3' border='0' alt='Buy Me a Coffee at ko-fi.com' /></a> <a href='https://discord.com/invite/527QQv9vFk' target='_blank'><img height='36' style='border:0px;height:36px;' src='https://cincydiscord.com/wp-content/uploads/2019/02/CINCYDISCORDJOIN.png' border='0' alt='Join the discord :)' /></a>
 <p>
 
-## Welcome to the PXL8 WebUI script!
+## Welcome to the PXL8 WebUI extension!
 **PXL8 is a Pixel Art specific model**, this repo contains the script to complete the pixel art workflow using Qunatization, Dithering, and more.
 
 **PXL8 V1 is provided for free, or donation at: https://devilismyfriend.gumroad.com/l/drzhn**
@@ -15,7 +15,7 @@
 
 Please consider supporting the project for better models and more features!
 
-This script will enable a Pixel Art workflow in Auto's WebUI, It is designed to work with the PXL8 model, but can be used with any model (with diminished results), features include:
+This extension script will enable a Pixel Art workflow in Auto's WebUI, It is designed to work with the PXL8 model, but can be used with any model (with diminished results), features include:
 
 - Downsample
 - Rescale
@@ -25,7 +25,9 @@ This script will enable a Pixel Art workflow in Auto's WebUI, It is designed to 
 
 
 ## Installation
-
-- Download the script and exe and place them in your script folder or download the zip and extract it there.
+- Method 1:
+    - Extensions -> Install from URL in Auto's WebUI, and paste the URL of this repo.
+- Method 2:
+    - Manually clone this repo into the `/stable-diffusion-webui/extensions` folder
 - Select PXL8 from the scripts menu in Auto's WebUI.
 - Dream big, and make some art!

--- a/scripts/pixl8.py
+++ b/scripts/pixl8.py
@@ -9,11 +9,12 @@ import subprocess
 import os
 import sys
 
+script_dir = scripts.basedir()
+
 #https://github.com/mcychan/nQuantCpp licensed under the GNU General Public License v3.0
 
 class Script(scripts.Script):  
     def __init__(self):
-        self.script_dir = os.path.dirname(os.path.realpath(__name__))+os.sep+'scripts'+os.sep
         self.nQuant = 'nQuantCpp.exe'
         self.palette_algos = ['PNN', 'PNNLAB', 'NEU', 'WU', 'EAS', 'SPA', 'DIV', 'DL3', 'MMC','Median', 'Maximum Coverage', 'Octree']
         self.color_palletes = ['Automatic','NES']
@@ -44,7 +45,7 @@ class Script(scripts.Script):
             isDither = 1 if dither else 0
             isSmart = 1 if palette_algo in self.palette_algos[:9] else 0
             #isCustomPalette = 1 if custom_palette != "None" else 0
-            temp = os.path.join(self.script_dir,"temp.png")
+            temp = os.path.join(script_dir,"temp.png")
             out_width, out_height = im.size
             sample_width = int(out_width / downscale)
             sample_height = int(out_height / downscale)
@@ -59,8 +60,8 @@ class Script(scripts.Script):
                 else:
                     work = work.convert("RGB")
                     work.save(temp)
-                    run = subprocess.run([os.path.join(self.script_dir, self.nQuant), temp, f"/m ",str(color_pal_size), f"/a ",palette_algo, "/d ","y" if isDither==1 else "n",], stdout=subprocess.DEVNULL)
-                    s_t = os.path.join(self.script_dir,f"temp-{palette_algo}quant{color_pal_size}.png")
+                    run = subprocess.run([os.path.join(script_dir, self.nQuant), temp, f"/m ",str(color_pal_size), f"/a ",palette_algo, "/d ","y" if isDither==1 else "n",], stdout=subprocess.DEVNULL)
+                    s_t = os.path.join(script_dir,f"temp-{palette_algo}quant{color_pal_size}.png")
                     #open s_t without holding it open
                     work = Image.open(s_t).convert("RGB")
                     os.remove(s_t)


### PR DESCRIPTION
Hi @devilismyfriend, first of all, thank you for making this script, it's very helpful.

This repo should probably be an extension, because installing scripts by copying them straight into the `/scripts` is not best practice as that folder is not gitignored in Auto's webui, and is reserved for internally included scripts.

Fortunately, it is very easy to transform your repo into an extension, just need to put the script inside the scripts subfolder and make a small change to the script_dir variable. My PR should address all of this, and I tested by installing it from my fork in the webui and using it.

Cheers!